### PR TITLE
Request to Merge

### DIFF
--- a/android/guava-testlib/src/com/google/common/testing/AbstractPackageSanityTests.java
+++ b/android/guava-testlib/src/com/google/common/testing/AbstractPackageSanityTests.java
@@ -232,6 +232,15 @@ public abstract class AbstractPackageSanityTests extends TestCase {
   @Test
   public void testNulls() throws Exception {
     for (Class<?> classToTest : findClassesToTest(loadClassesInPackage(), NULL_TEST_METHOD_NAMES)) {
+      if (classToTest.getSimpleName().equals("ReflectionFreeAssertThrows")) {
+        /*
+         * These classes handle null properly but throw IllegalArgumentException for the default
+         * Class argument that this test uses. Normally we'd fix that by declaring a
+         * ReflectionFreeAssertThrowsTest with a testNulls method, but that's annoying to have to do
+         * for a package-private utility class. So we skip the class entirely instead.
+         */
+        continue;
+      }
       try {
         tester.doTestNulls(classToTest, visibility);
       } catch (Throwable e) {

--- a/android/guava-tests/test/com/google/common/base/ReflectionFreeAssertThrows.java
+++ b/android/guava-tests/test/com/google/common/base/ReflectionFreeAssertThrows.java
@@ -14,6 +14,8 @@
 
 package com.google.common.base;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
@@ -22,8 +24,6 @@ import com.google.common.base.TestExceptions.SomeError;
 import com.google.common.base.TestExceptions.SomeOtherCheckedException;
 import com.google.common.base.TestExceptions.SomeUncheckedException;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.ExecutionError;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.UnsupportedCharsetException;
@@ -67,6 +67,8 @@ final class ReflectionFreeAssertThrows {
 
   private static <T extends Throwable> T doAssertThrows(
       Class<T> expectedThrowable, ThrowingSupplier supplier, boolean userPassedSupplier) {
+    checkNotNull(expectedThrowable);
+    checkNotNull(supplier);
     Predicate<Throwable> predicate = INSTANCE_OF.get(expectedThrowable);
     if (predicate == null) {
       throw new IllegalArgumentException(
@@ -132,7 +134,6 @@ final class ReflectionFreeAssertThrows {
           .put(
               ConcurrentModificationException.class,
               e -> e instanceof ConcurrentModificationException)
-          .put(ExecutionError.class, e -> e instanceof ExecutionError)
           .put(ExecutionException.class, e -> e instanceof ExecutionException)
           .put(IllegalArgumentException.class, e -> e instanceof IllegalArgumentException)
           .put(IllegalStateException.class, e -> e instanceof IllegalStateException)
@@ -146,7 +147,6 @@ final class ReflectionFreeAssertThrows {
           .put(SomeOtherCheckedException.class, e -> e instanceof SomeOtherCheckedException)
           .put(SomeUncheckedException.class, e -> e instanceof SomeUncheckedException)
           .put(TimeoutException.class, e -> e instanceof TimeoutException)
-          .put(UncheckedExecutionException.class, e -> e instanceof UncheckedExecutionException)
           .put(UnsupportedCharsetException.class, e -> e instanceof UnsupportedCharsetException)
           .put(UnsupportedOperationException.class, e -> e instanceof UnsupportedOperationException)
           .put(VerifyException.class, e -> e instanceof VerifyException)

--- a/android/guava-tests/test/com/google/common/collect/ReflectionFreeAssertThrows.java
+++ b/android/guava-tests/test/com/google/common/collect/ReflectionFreeAssertThrows.java
@@ -14,6 +14,8 @@
 
 package com.google.common.collect;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
@@ -24,8 +26,6 @@ import com.google.common.collect.TestExceptions.SomeCheckedException;
 import com.google.common.collect.TestExceptions.SomeError;
 import com.google.common.collect.TestExceptions.SomeOtherCheckedException;
 import com.google.common.collect.TestExceptions.SomeUncheckedException;
-import com.google.common.util.concurrent.ExecutionError;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.UnsupportedCharsetException;
@@ -69,6 +69,8 @@ final class ReflectionFreeAssertThrows {
 
   private static <T extends Throwable> T doAssertThrows(
       Class<T> expectedThrowable, ThrowingSupplier supplier, boolean userPassedSupplier) {
+    checkNotNull(expectedThrowable);
+    checkNotNull(supplier);
     Predicate<Throwable> predicate = INSTANCE_OF.get(expectedThrowable);
     if (predicate == null) {
       throw new IllegalArgumentException(
@@ -134,7 +136,6 @@ final class ReflectionFreeAssertThrows {
           .put(
               ConcurrentModificationException.class,
               e -> e instanceof ConcurrentModificationException)
-          .put(ExecutionError.class, e -> e instanceof ExecutionError)
           .put(ExecutionException.class, e -> e instanceof ExecutionException)
           .put(IllegalArgumentException.class, e -> e instanceof IllegalArgumentException)
           .put(IllegalStateException.class, e -> e instanceof IllegalStateException)
@@ -149,7 +150,6 @@ final class ReflectionFreeAssertThrows {
           .put(SomeOtherCheckedException.class, e -> e instanceof SomeOtherCheckedException)
           .put(SomeUncheckedException.class, e -> e instanceof SomeUncheckedException)
           .put(TimeoutException.class, e -> e instanceof TimeoutException)
-          .put(UncheckedExecutionException.class, e -> e instanceof UncheckedExecutionException)
           .put(UnsupportedCharsetException.class, e -> e instanceof UnsupportedCharsetException)
           .put(UnsupportedOperationException.class, e -> e instanceof UnsupportedOperationException)
           .put(VerifyException.class, e -> e instanceof VerifyException)

--- a/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -295,7 +295,11 @@ public final class ImmutableSortedMap<K, V> extends ImmutableMap<K, V>
       V v8,
       K k9,
       V v9) {
-    return fromEntries(
+    /*
+     * This explicit type parameter works around what seems to be a javac bug in certain
+     * configurations: b/339186525#comment6
+     */
+    return ImmutableSortedMap.<K, V>fromEntries(
         entryOf(k1, v1),
         entryOf(k2, v2),
         entryOf(k3, v3),

--- a/guava-testlib/src/com/google/common/testing/AbstractPackageSanityTests.java
+++ b/guava-testlib/src/com/google/common/testing/AbstractPackageSanityTests.java
@@ -233,6 +233,15 @@ public abstract class AbstractPackageSanityTests extends TestCase {
   @Test
   public void testNulls() throws Exception {
     for (Class<?> classToTest : findClassesToTest(loadClassesInPackage(), NULL_TEST_METHOD_NAMES)) {
+      if (classToTest.getSimpleName().equals("ReflectionFreeAssertThrows")) {
+        /*
+         * These classes handle null properly but throw IllegalArgumentException for the default
+         * Class argument that this test uses. Normally we'd fix that by declaring a
+         * ReflectionFreeAssertThrowsTest with a testNulls method, but that's annoying to have to do
+         * for a package-private utility class. So we skip the class entirely instead.
+         */
+        continue;
+      }
       try {
         tester.doTestNulls(classToTest, visibility);
       } catch (Throwable e) {

--- a/guava-tests/test/com/google/common/base/ReflectionFreeAssertThrows.java
+++ b/guava-tests/test/com/google/common/base/ReflectionFreeAssertThrows.java
@@ -14,6 +14,8 @@
 
 package com.google.common.base;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
@@ -22,8 +24,6 @@ import com.google.common.base.TestExceptions.SomeError;
 import com.google.common.base.TestExceptions.SomeOtherCheckedException;
 import com.google.common.base.TestExceptions.SomeUncheckedException;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.ExecutionError;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.UnsupportedCharsetException;
@@ -67,6 +67,8 @@ final class ReflectionFreeAssertThrows {
 
   private static <T extends Throwable> T doAssertThrows(
       Class<T> expectedThrowable, ThrowingSupplier supplier, boolean userPassedSupplier) {
+    checkNotNull(expectedThrowable);
+    checkNotNull(supplier);
     Predicate<Throwable> predicate = INSTANCE_OF.get(expectedThrowable);
     if (predicate == null) {
       throw new IllegalArgumentException(
@@ -132,7 +134,6 @@ final class ReflectionFreeAssertThrows {
           .put(
               ConcurrentModificationException.class,
               e -> e instanceof ConcurrentModificationException)
-          .put(ExecutionError.class, e -> e instanceof ExecutionError)
           .put(ExecutionException.class, e -> e instanceof ExecutionException)
           .put(IllegalArgumentException.class, e -> e instanceof IllegalArgumentException)
           .put(IllegalStateException.class, e -> e instanceof IllegalStateException)
@@ -146,7 +147,6 @@ final class ReflectionFreeAssertThrows {
           .put(SomeOtherCheckedException.class, e -> e instanceof SomeOtherCheckedException)
           .put(SomeUncheckedException.class, e -> e instanceof SomeUncheckedException)
           .put(TimeoutException.class, e -> e instanceof TimeoutException)
-          .put(UncheckedExecutionException.class, e -> e instanceof UncheckedExecutionException)
           .put(UnsupportedCharsetException.class, e -> e instanceof UnsupportedCharsetException)
           .put(UnsupportedOperationException.class, e -> e instanceof UnsupportedOperationException)
           .put(VerifyException.class, e -> e instanceof VerifyException)

--- a/guava-tests/test/com/google/common/collect/ReflectionFreeAssertThrows.java
+++ b/guava-tests/test/com/google/common/collect/ReflectionFreeAssertThrows.java
@@ -14,6 +14,8 @@
 
 package com.google.common.collect;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
@@ -24,8 +26,6 @@ import com.google.common.collect.TestExceptions.SomeCheckedException;
 import com.google.common.collect.TestExceptions.SomeError;
 import com.google.common.collect.TestExceptions.SomeOtherCheckedException;
 import com.google.common.collect.TestExceptions.SomeUncheckedException;
-import com.google.common.util.concurrent.ExecutionError;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.UnsupportedCharsetException;
@@ -69,6 +69,8 @@ final class ReflectionFreeAssertThrows {
 
   private static <T extends Throwable> T doAssertThrows(
       Class<T> expectedThrowable, ThrowingSupplier supplier, boolean userPassedSupplier) {
+    checkNotNull(expectedThrowable);
+    checkNotNull(supplier);
     Predicate<Throwable> predicate = INSTANCE_OF.get(expectedThrowable);
     if (predicate == null) {
       throw new IllegalArgumentException(
@@ -134,7 +136,6 @@ final class ReflectionFreeAssertThrows {
           .put(
               ConcurrentModificationException.class,
               e -> e instanceof ConcurrentModificationException)
-          .put(ExecutionError.class, e -> e instanceof ExecutionError)
           .put(ExecutionException.class, e -> e instanceof ExecutionException)
           .put(IllegalArgumentException.class, e -> e instanceof IllegalArgumentException)
           .put(IllegalStateException.class, e -> e instanceof IllegalStateException)
@@ -149,7 +150,6 @@ final class ReflectionFreeAssertThrows {
           .put(SomeOtherCheckedException.class, e -> e instanceof SomeOtherCheckedException)
           .put(SomeUncheckedException.class, e -> e instanceof SomeUncheckedException)
           .put(TimeoutException.class, e -> e instanceof TimeoutException)
-          .put(UncheckedExecutionException.class, e -> e instanceof UncheckedExecutionException)
           .put(UnsupportedCharsetException.class, e -> e instanceof UnsupportedCharsetException)
           .put(UnsupportedOperationException.class, e -> e instanceof UnsupportedOperationException)
           .put(VerifyException.class, e -> e instanceof VerifyException)

--- a/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -294,7 +294,11 @@ public final class ImmutableSortedMap<K, V> extends ImmutableMap<K, V>
       V v8,
       K k9,
       V v9) {
-    return fromEntries(
+    /*
+     * This explicit type parameter works around what seems to be a javac bug in certain
+     * configurations: b/339186525#comment6
+     */
+    return ImmutableSortedMap.<K, V>fromEntries(
         entryOf(k1, v1),
         entryOf(k2, v2),
         entryOf(k3, v3),


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Enhanced `AbstractPackageSanityTests` to skip `ReflectionFreeAssertThrows` class in null tests, providing a rationale in comments.
- Added null checks for `expectedThrowable` and `supplier` in `ReflectionFreeAssertThrows` classes to improve error handling.
- Removed unused dependencies on `ExecutionError` and `UncheckedExecutionException` to clean up the codebase.
- Added explicit type parameter in `ImmutableSortedMap` to workaround a javac bug.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractPackageSanityTests.java</strong><dd><code>Skip `ReflectionFreeAssertThrows` class in null tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/guava-testlib/src/com/google/common/testing/AbstractPackageSanityTests.java

<li>Added a condition to skip <code>ReflectionFreeAssertThrows</code> class in null <br>tests.<br> <li> Provided reasoning for skipping the class in comments.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/guava/pull/1/files#diff-20990d946d7d6cd18389ec4e39344b0f3bcc9963340aacc8058098626dddf312">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AbstractPackageSanityTests.java</strong><dd><code>Skip `ReflectionFreeAssertThrows` class in null tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

guava-testlib/src/com/google/common/testing/AbstractPackageSanityTests.java

<li>Added a condition to skip <code>ReflectionFreeAssertThrows</code> class in null <br>tests.<br> <li> Provided reasoning for skipping the class in comments.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/guava/pull/1/files#diff-d284840b1dab2823765b31b0443288ec83dff580cd18d7494f583d08b8a2254a">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ReflectionFreeAssertThrows.java</strong><dd><code>Add null checks and remove unused dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/guava-tests/test/com/google/common/base/ReflectionFreeAssertThrows.java

<li>Added null checks for <code>expectedThrowable</code> and <code>supplier</code>.<br> <li> Removed dependencies on <code>ExecutionError</code> and <br><code>UncheckedExecutionException</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/guava/pull/1/files#diff-e03a1c3ac002eb0aa25e48bb1e36e3e37194ce6ceb969769886400d9c6faba4a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReflectionFreeAssertThrows.java</strong><dd><code>Add null checks and remove unused dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/guava-tests/test/com/google/common/collect/ReflectionFreeAssertThrows.java

<li>Added null checks for <code>expectedThrowable</code> and <code>supplier</code>.<br> <li> Removed dependencies on <code>ExecutionError</code> and <br><code>UncheckedExecutionException</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/guava/pull/1/files#diff-bfb44a59b83e8227f5fafba40271914a2e5f96d2eb921c86fb9bb7e36a9c7e4c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ImmutableSortedMap.java</strong><dd><code>Add explicit type parameter to workaround javac bug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/guava/src/com/google/common/collect/ImmutableSortedMap.java

- Added explicit type parameter to workaround a javac bug.



</details>


  </td>
  <td><a href="https://github.com/maorethians/guava/pull/1/files#diff-a84acf201f21f02c4c457288e40c7fada533877778996a20cfe766bd51a10b65">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReflectionFreeAssertThrows.java</strong><dd><code>Add null checks and remove unused dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

guava-tests/test/com/google/common/base/ReflectionFreeAssertThrows.java

<li>Added null checks for <code>expectedThrowable</code> and <code>supplier</code>.<br> <li> Removed dependencies on <code>ExecutionError</code> and <br><code>UncheckedExecutionException</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/guava/pull/1/files#diff-0429f08762308ffe99a67aabe7a3ba8fac15940665a30d7190dac10e8f6f7ff2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ReflectionFreeAssertThrows.java</strong><dd><code>Add null checks and remove unused dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

guava-tests/test/com/google/common/collect/ReflectionFreeAssertThrows.java

<li>Added null checks for <code>expectedThrowable</code> and <code>supplier</code>.<br> <li> Removed dependencies on <code>ExecutionError</code> and <br><code>UncheckedExecutionException</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/guava/pull/1/files#diff-9fe8c5b7b46e5fe3f483ee861e35a66df1c13a5dcee720fdb11342dbeced32bc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ImmutableSortedMap.java</strong><dd><code>Add explicit type parameter to workaround javac bug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

guava/src/com/google/common/collect/ImmutableSortedMap.java

- Added explicit type parameter to workaround a javac bug.



</details>


  </td>
  <td><a href="https://github.com/maorethians/guava/pull/1/files#diff-2019dfe42a01439e6c67e828a55e93eaa04434003aca589f949c5f5f439ebee3">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information